### PR TITLE
Bruk exportUCServer i stedet for exportUCServer2

### DIFF
--- a/dev/oppsettArnfinn.R
+++ b/dev/oppsettArnfinn.R
@@ -1,6 +1,6 @@
 sship::dec(
-  "c://Users/ast046/Downloads/intensiv126642fed.sql.gz__20250611_092542.tar.gz",
-  keyfile = "p://.ssh/id_rsa",
+  "c://Users/ast046/Downloads/intensiv141abf297.sql.gz__20260219_102507.tar.gz",
+  keyfile = "c://Users/ast046/.ssh/id_rsa",
   target_dir = "c://Users/ast046/Downloads/")
 
 devtools::install("../rapbase/.", upgrade = FALSE)

--- a/inst/appErHer/appIntensivEnFilFasUt.R
+++ b/inst/appErHer/appIntensivEnFilFasUt.R
@@ -1454,7 +1454,7 @@ server <- function(input, output, session) { #
 
          #----------- Eksport ----------------
          ## brukerkontroller
-         rapbase::exportUCServer2("intensivExport", "nir",
+         rapbase::exportUCServer("intensivExport", "nir",
                                  "intensiv",
                                  eligible = vis_rapp
          )


### PR DESCRIPTION
Har fikset `exportUCServer` slik at den fungerer som `exportUCServer2`, slik at vi kan fase ut og slette `exportUCServer2`. Se https://github.com/Rapporteket/rapbase/pull/360. Må bruke ny versjon av rapbase (3.3.0) for at det skal fungere.

